### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "tpu",
     "name_pretty": "Cloud TPU",
     "product_documentation": "https://cloud.google.com/tpu/",
-    "client_documentation": "https://googleapis.dev/python/tpu/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/tpu/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ integrated circuits (ASICs) used to accelerate machine learning workloads.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-tpu.svg
    :target: https://pypi.org/project/google-cloud-tpu/
 .. _Cloud TPU: https://cloud.google.com/tpu
-.. _Client Library Documentation: https://googleapis.dev/python/tpu/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/tpu/latest
 .. _Product Documentation:  https://cloud.google.com/tpu/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.