### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-### [1.3.3](https://github.com/googleapis/python-tpu/compare/v1.3.2...v1.3.3) (2022-05-05)
+## [1.3.3](https://github.com/googleapis/python-tpu/compare/v1.3.2...v1.3.3) (2022-05-05)
 
 
 ### Documentation
 
 * fix docstring for map fields ([5c230d6](https://github.com/googleapis/python-tpu/commit/5c230d6ff4533f572c6315889ca0ff7d5f6a0882))
 
-### [1.3.2](https://github.com/googleapis/python-tpu/compare/v1.3.1...v1.3.2) (2022-03-05)
+## [1.3.2](https://github.com/googleapis/python-tpu/compare/v1.3.1...v1.3.2) (2022-03-05)
 
 
 ### Bug Fixes
 
 * **deps:** require google-api-core>=1.31.5, >=2.3.2 ([#89](https://github.com/googleapis/python-tpu/issues/89)) ([07b8c1a](https://github.com/googleapis/python-tpu/commit/07b8c1acd38d029fb792378f2970191f36b80445))
 
-### [1.3.1](https://github.com/googleapis/python-tpu/compare/v1.3.0...v1.3.1) (2022-02-11)
+## [1.3.1](https://github.com/googleapis/python-tpu/compare/v1.3.0...v1.3.1) (2022-02-11)
 
 
 ### Documentation
@@ -33,7 +33,7 @@
 
 * resolve DuplicateCredentialArgs error when using credentials_file ([776dbea](https://github.com/googleapis/python-tpu/commit/776dbea03b1bc19e930b62708ec68bce49f4d06d))
 
-### [1.2.1](https://www.github.com/googleapis/python-tpu/compare/v1.2.0...v1.2.1) (2021-11-01)
+## [1.2.1](https://www.github.com/googleapis/python-tpu/compare/v1.2.0...v1.2.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -61,14 +61,14 @@
 
 * add context manager support in client ([#48](https://www.github.com/googleapis/python-tpu/issues/48)) ([f51a651](https://www.github.com/googleapis/python-tpu/commit/f51a6513f7f13c8aa0c9b06a63134a04ae6463f2))
 
-### [1.0.2](https://www.github.com/googleapis/python-tpu/compare/v1.0.1...v1.0.2) (2021-09-30)
+## [1.0.2](https://www.github.com/googleapis/python-tpu/compare/v1.0.1...v1.0.2) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([306f0f7](https://www.github.com/googleapis/python-tpu/commit/306f0f7703ba2e1d3c1dc0201b0bd9142cd1cfde))
 
-### [1.0.1](https://www.github.com/googleapis/python-tpu/compare/v1.0.0...v1.0.1) (2021-09-24)
+## [1.0.1](https://www.github.com/googleapis/python-tpu/compare/v1.0.0...v1.0.1) (2021-09-24)
 
 
 ### Bug Fixes
@@ -82,7 +82,7 @@
 
 * bump release level to production/stable ([#28](https://www.github.com/googleapis/python-tpu/issues/28)) ([64818bf](https://www.github.com/googleapis/python-tpu/commit/64818bfa56c89569bb961c3463872404cee990cf))
 
-### [0.2.2](https://www.github.com/googleapis/python-tpu/compare/v0.2.1...v0.2.2) (2021-07-29)
+## [0.2.2](https://www.github.com/googleapis/python-tpu/compare/v0.2.1...v0.2.2) (2021-07-29)
 
 
 ### Bug Fixes
@@ -99,7 +99,7 @@
 
 * release as 0.2.2 ([#25](https://www.github.com/googleapis/python-tpu/issues/25)) ([53e254f](https://www.github.com/googleapis/python-tpu/commit/53e254fbd3148eacf72236fe264049570e5f1c95))
 
-### [0.2.1](https://www.github.com/googleapis/python-tpu/compare/v0.2.0...v0.2.1) (2021-07-21)
+## [0.2.1](https://www.github.com/googleapis/python-tpu/compare/v0.2.0...v0.2.1) (2021-07-21)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.